### PR TITLE
feat: Add process list to system stats dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+glances-go.exe

--- a/main.go
+++ b/main.go
@@ -1,34 +1,34 @@
 package main
 
 import (
-    "encoding/json"
-    "log"
-    "net/http"
+	"encoding/json"
+	"log"
+	"net/http"
 )
 
 // Handler for the /stats endpoint
 func statsHandler(w http.ResponseWriter, r *http.Request) {
-    stats, err := collectStats()
-    if err != nil {
-        http.Error(w, "Error collecting stats", http.StatusInternalServerError)
-        return
-    }
+	stats, err := collectStats()
+	if err != nil {
+		http.Error(w, "Error collecting stats", http.StatusInternalServerError)
+		return
+	}
 
-    w.Header().Set("Content-Type", "application/json")
-    json.NewEncoder(w).Encode(stats)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(stats)
 }
 
 func main() {
-    // Serve static files from a 'web' directory
-    fs := http.FileServer(http.Dir("./web"))
-    http.Handle("/", fs)
+	// Serve static files from a 'web' directory
+	fs := http.FileServer(http.Dir("./web"))
+	http.Handle("/", fs)
 
-    // Handle the stats endpoint
-    http.HandleFunc("/stats", statsHandler)
+	// Handle the stats endpoint
+	http.HandleFunc("/stats", statsHandler)
 
-    log.Println("Starting server on :8080...")
-    err := http.ListenAndServe(":8080", nil)
-    if err != nil {
-        log.Fatal(err)
-    }
+	log.Println("Starting server on :8080...")
+	err := http.ListenAndServe(":8080", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/stats.go
+++ b/stats.go
@@ -1,38 +1,86 @@
 package main
 
 import (
-    "github.com/shirou/gopsutil/v3/cpu"
-    "github.com/shirou/gopsutil/v3/mem"
-    "time"
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/mem"
+	"github.com/shirou/gopsutil/v3/process"
+	"sort"
+	"time"
 )
 
+// Process holds information about a single running process
+type Process struct {
+	Pid    int32   `json:"pid"`
+	Name   string  `json:"name"`
+	CPU    float64 `json:"cpu"`
+	Memory float32 `json:"memory"`
+}
+
+// SystemStats is the main structure for all system metrics
 type SystemStats struct {
-    CPUUsage       float64 `json:"cpu_usage"`
-    MemTotal       uint64  `json:"mem_total"`
-    MemUsed        uint64  `json:"mem_used"`
-    MemUsedPercent float64 `json:"mem_used_percent"`
+	CPUUsage       float64   `json:"cpu_usage"`
+	MemTotal       uint64    `json:"mem_total"`
+	MemUsed        uint64    `json:"mem_used"`
+	MemUsedPercent float64   `json:"mem_used_percent"`
+	Processes      []Process `json:"processes"`
 }
 
 func collectStats() (SystemStats, error) {
-    var stats SystemStats
+	var stats SystemStats
 
-    // CPU Usage
-    cpuPercentages, err := cpu.Percent(time.Second, false)
-    if err != nil {
-        return stats, err
-    }
-    if len(cpuPercentages) > 0 {
-        stats.CPUUsage = cpuPercentages[0]
-    }
+	// CPU Usage
+	cpuPercentages, err := cpu.Percent(time.Second, false)
+	if err != nil {
+		return stats, err
+	}
+	if len(cpuPercentages) > 0 {
+		stats.CPUUsage = cpuPercentages[0]
+	}
 
-    // Memory Usage
-    vm, err := mem.VirtualMemory()
-    if err != nil {
-        return stats, err
-    }
-    stats.MemTotal = vm.Total
-    stats.MemUsed = vm.Used
-    stats.MemUsedPercent = vm.UsedPercent
+	// Memory Usage
+	vm, err := mem.VirtualMemory()
+	if err != nil {
+		return stats, err
+	}
+	stats.MemTotal = vm.Total
+	stats.MemUsed = vm.Used
+	stats.MemUsedPercent = vm.UsedPercent
 
-    return stats, nil
+	// Process List
+	pids, err := process.Pids()
+	if err != nil {
+		return stats, err
+	}
+
+	var processes []Process
+	for _, pid := range pids {
+		p, err := process.NewProcess(pid)
+		if err != nil {
+			continue // Skip processes that might have terminated
+		}
+		name, _ := p.Name()
+		cpu, _ := p.CPUPercent()
+		mem, _ := p.MemoryPercent()
+
+		processes = append(processes, Process{
+			Pid:     pid,
+			Name:    name,
+			CPU:     cpu,
+			Memory:  mem,
+		})
+	}
+
+	// Sort processes by CPU usage (descending)
+	sort.Slice(processes, func(i, j int) bool {
+		return processes[i].CPU > processes[j].CPU
+	})
+
+	// Limit to top 20 processes
+	if len(processes) > 20 {
+		stats.Processes = processes[:20]
+	} else {
+		stats.Processes = processes
+	}
+
+	return stats, nil
 }

--- a/web/index.html
+++ b/web/index.html
@@ -19,6 +19,22 @@
                 <p>Usage: <span id="mem-percent">...</span>%</p>
             </div>
         </div>
+        <div id="process-container">
+            <h2>Processes (Top 20 by CPU)</h2>
+            <table id="process-table">
+                <thead>
+                    <tr>
+                        <th>PID</th>
+                        <th>Name</th>
+                        <th>CPU %</th>
+                        <th>Mem %</th>
+                    </tr>
+                </thead>
+                <tbody id="process-list-body">
+                    <!-- JS will populate this -->
+                </tbody>
+            </table>
+        </div>
     </div>
     <script src="script.js"></script>
 </body>

--- a/web/script.js
+++ b/web/script.js
@@ -11,6 +11,23 @@ function fetchStats() {
             document.getElementById('mem-used').textContent = memUsedGB;
             document.getElementById('mem-total').textContent = memTotalGB;
             document.getElementById('mem-percent').textContent = data.mem_used_percent.toFixed(2);
+
+            // Update Process List
+            const processBody = document.getElementById('process-list-body');
+            processBody.innerHTML = ''; // Clear old data
+
+            if (data.processes) {
+                data.processes.forEach(proc => {
+                    const row = document.createElement('tr');
+                    row.innerHTML = `
+                        <td>${proc.pid}</td>
+                        <td>${proc.name}</td>
+                        <td>${proc.cpu.toFixed(2)}</td>
+                        <td>${proc.memory.toFixed(2)}</td>
+                    `;
+                    processBody.appendChild(row);
+                });
+            }
         })
         .catch(error => console.error('Error fetching stats:', error));
 }

--- a/web/style.css
+++ b/web/style.css
@@ -1,49 +1,87 @@
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    background-color: #f0f2f5;
-    color: #1c1e21;
+    font-family: "DejaVu Sans Mono", "Consolas", "Monaco", monospace;
+    background-color: #1e1e1e;
+    color: #d4d4d4;
     margin: 0;
-    padding: 20px;
+    padding: 1em;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
 }
 
 h1 {
     text-align: center;
-    color: #1877f2;
-}
-
-.container {
-    max-width: 800px;
-    margin: 20px auto;
-    padding: 20px;
-    background-color: #ffffff;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    color: #4ec9b0; /* Teal */
+    font-weight: normal;
+    margin-bottom: 2em;
 }
 
 .stats-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2em;
+    margin-bottom: 2em;
 }
 
 .stats-card {
-    padding: 20px;
-    border: 1px solid #dddfe2;
-    border-radius: 8px;
+    background-color: #252526;
+    padding: 1.5em;
+    border-radius: 4px;
+    border-left: 4px solid #4ec9b0; /* Teal accent */
 }
 
 .stats-card h2 {
     margin-top: 0;
-    color: #606770;
-    font-size: 1.2em;
+    color: #9cdcfe; /* Light Blue */
+    font-size: 1.1em;
+    border-bottom: 1px solid #333;
+    padding-bottom: 0.5em;
+    margin-bottom: 1em;
 }
 
 .stats-card p {
-    margin: 5px 0;
-    font-size: 1em;
+    margin: 0.5em 0;
+    font-size: 0.9em;
 }
 
 .stats-card span {
     font-weight: bold;
-    color: #1877f2;
+    color: #b5cea8; /* Green */
+}
+
+#process-container {
+    background-color: #252526;
+    padding: 1.5em;
+    border-radius: 4px;
+}
+
+#process-container h2 {
+    margin-top: 0;
+    color: #9cdcfe; /* Light Blue */
+}
+
+#process-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9em;
+}
+
+#process-table thead {
+    text-align: left;
+    color: #4ec9b0; /* Teal */
+}
+
+#process-table th, #process-table td {
+    padding: 0.6em 0.8em;
+    border-bottom: 1px solid #333;
+}
+
+#process-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+#process-table td:nth-child(3), #process-table td:nth-child(4) {
+    color: #b5cea8; /* Green */
 }


### PR DESCRIPTION
-Extended backend to collect and return top 20 processes by CPU usage, including their PID, name, CPU, and memory percent. 
-Updated frontend to display this process list in a new table, and restyled the UI for a dark theme and improved layout.

Closes #1 