### PR TITLE
feat: add cli-flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,34 +2,58 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"log"
 	"net/http"
+	"time"
 )
 
 // Handler for the /stats endpoint
-func statsHandler(w http.ResponseWriter, r *http.Request) {
-	stats, err := collectStats()
-	if err != nil {
-		http.Error(w, "Error collecting stats", http.StatusInternalServerError)
-		return
-	}
+func statsHandler(cacheTTL time.Duration, maxProcesses int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		stats, err := collectStats(cacheTTL, maxProcesses)
+		if err != nil {
+			http.Error(w, "Error collecting stats", http.StatusInternalServerError)
+			return
+		}
 
-	w.Header().Set("Content-Type", "application/json")
-	    err = json.NewEncoder(w).Encode(stats)
-	    if err != nil {
-	        log.Printf("Error encoding stats: %v", err)
-	    }}
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(stats)
+		if err != nil {
+			log.Printf("Error encoding stats: %v", err)
+		}
+	}
+}
 
 func main() {
+	var (
+		port         string
+		cacheTTL     time.Duration
+		maxProcesses int
+	)
+
+	// Custom usage: print flags only.
+	flag.Usage = func() {
+		flag.PrintDefaults()
+	}
+
+	// CLI flags
+	flag.StringVar(&port, "port", "8080", "HTTP listen port (e.g., 8080)")
+	flag.DurationVar(&cacheTTL, "cache-ttl", 2*time.Second,
+		"How long to cache metrics (unit required; e.g., 500ms, 0.5s, 2s)")
+	flag.IntVar(&maxProcesses, "max-processes", 20, "Maximum number of OS processes to monitor")
+	flag.Parse()
+
 	// Serve static files from a 'web' directory
 	fs := http.FileServer(http.Dir("./web"))
 	http.Handle("/", fs)
 
 	// Handle the stats endpoint
-	http.HandleFunc("/stats", statsHandler)
+	http.HandleFunc("/stats", statsHandler(cacheTTL, maxProcesses))
 
-	log.Println("Starting server on :8080...")
-	err := http.ListenAndServe(":8080", nil)
+	addr := ":" + port
+	log.Printf("Starting server on %s...\n", addr)
+	err := http.ListenAndServe(addr, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/stats.go
+++ b/stats.go
@@ -36,13 +36,13 @@ type CpuInfo struct {
 
 // NetworkInterface holds information about a single network interface
 type NetworkInterface struct {
-	Name      string  `json:"name"`
-	Rx        uint64  `json:"rx"`
-	Tx        uint64  `json:"tx"`
-	RxSpeed   float64 `json:"rx_speed"`
-	TxSpeed   float64 `json:"tx_speed"`
-	RxUnit    string  `json:"rx_unit"`
-	TxUnit    string  `json:"tx_unit"`
+	Name    string  `json:"name"`
+	Rx      uint64  `json:"rx"`
+	Tx      uint64  `json:"tx"`
+	RxSpeed float64 `json:"rx_speed"`
+	TxSpeed float64 `json:"tx_speed"`
+	RxUnit  string  `json:"rx_unit"`
+	TxUnit  string  `json:"tx_unit"`
 }
 
 // SystemStats is the main structure for all system metrics
@@ -58,18 +58,18 @@ type SystemStats struct {
 }
 
 var (
-	statsCache         SystemStats
-	cacheMutex         sync.Mutex
-	cacheTime          time.Time
-	lastNetStats       []net.IOCountersStat
-	lastNetStatsTime   time.Time
+	statsCache       SystemStats
+	cacheMutex       sync.Mutex
+	cacheTime        time.Time
+	lastNetStats     []net.IOCountersStat
+	lastNetStatsTime time.Time
 )
 
-func collectStats() (SystemStats, error) {
+func collectStats(cacheTTL time.Duration, maxProcesses int) (SystemStats, error) {
 	cacheMutex.Lock()
 	defer cacheMutex.Unlock()
 
-	if time.Since(cacheTime) < 2*time.Second {
+	if time.Since(cacheTime) < cacheTTL {
 		return statsCache, nil
 	}
 
@@ -194,9 +194,9 @@ func collectStats() (SystemStats, error) {
 		return processes[i].CPU > processes[j].CPU
 	})
 
-	// Limit to top 20 processes
-	if len(processes) > 20 {
-		stats.Processes = processes[:20]
+	// Limit to top maxProcesses processes
+	if len(processes) > maxProcesses {
+		stats.Processes = processes[:maxProcesses]
 	} else {
 		stats.Processes = processes
 	}


### PR DESCRIPTION
**What changed**

Switched /stats to a factory/closure: statsHandler(cacheTTL, maxProcesses) http.HandlerFunc — no globals, easier tests.

Clean, CLI flags

**Flags**

--port (string, default 8080) — HTTP listen port.

--cache-ttl (duration, default 2s) — Cache TTL (unit required; e.g., 500ms, 0.5s, 2s).

--max-processes (int, default 20) — Max number of OS processes to monitor.

**Usage**
```
# Help
./monitor --help

# Success
./monitor --port=8088 --max-processes=50 --cache-ttl=1s
# -> Starting server on :8088...

# Error (shows hint + options)
./monitor --cache-ttl=0.5
# -> invalid value "0.5" for flag -cache-ttl: parse error
# -> ... shows options with examples (500ms, 0.5s, 2s)
```