### PR TITLE
feat(stats): Add file system usage stats to dashboard

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -42,8 +42,23 @@
             </tbody>
           </table>
         </div>
-      </div>
-      <div id="per-core-usage-container">
+        <div class="stats-card fs-card">
+          <h2>File System</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Mount</th>
+                <th>Used</th>
+                <th>Total</th>
+                <th>Used %</th>
+              </tr>
+            </thead>
+            <tbody id="fs-body">
+              <!-- JS will populate this -->
+            </tbody>
+          </table>
+        </div>
+      </div>      <div id="per-core-usage-container">
         <h2>Usage per core</h2>
         <table id="per-core-usage-table">
           <thead>

--- a/web/script.js
+++ b/web/script.js
@@ -32,8 +32,35 @@ function fetchStats() {
             if (data.network) {
                 updateNetworkUsage(data.network);
             }
+
+            if (data.filesystems) {
+                updateFileSystemUsage(data.filesystems);
+            }
         })
         .catch(error => console.error('Error fetching stats:', error));
+}
+
+function updateFileSystemUsage(fsData) {
+    const tbody = document.getElementById('fs-body');
+    tbody.innerHTML = '';
+
+    if (!fsData || fsData.length === 0) {
+        const row = document.createElement('tr');
+        row.innerHTML = `<td colspan="4">No file systems found.</td>`;
+        tbody.appendChild(row);
+        return;
+    }
+
+    fsData.forEach(fs => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+            <td>${fs.mountpoint}</td>
+            <td>${(fs.used / 1e9).toFixed(2)} GB</td>
+            <td>${(fs.total / 1e9).toFixed(2)} GB</td>
+            <td>${fs.used_perc.toFixed(2)}%</td>
+        `;
+        tbody.appendChild(row);
+    });
 }
 
 function updateNetworkUsage(networkData) {

--- a/web/style.css
+++ b/web/style.css
@@ -20,9 +20,20 @@ h1 {
 
 .stats-grid {
     display: grid;
-    grid-template-columns: 1fr 0.8fr 1.2fr;
+    grid-template-columns: 1fr 1fr;
     gap: 2em;
     margin-bottom: 2em;
+}
+
+.fs-card table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.fs-card th, .fs-card td {
+    text-align: left;
+    padding: 0.4em 0;
+    white-space: nowrap;
 }
 
 .network-card table {


### PR DESCRIPTION
- Introduces file system statistics collection in the backend using gopsutil/disk, adds a new FileSystemStat struct, and exposes this data via the API. 
- Updates the frontend to display file system usage in a new table, including used, total, and percentage used for each mount point, and styles the new section accordingly.

Closes #10 