### PR TITLE
feat: Display OS, system time, and uptime

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,11 @@
   </head>
   <body>
     <div class="container">
+      <div id="system-info-container">
+        <p>OS: <span id="os-distro">...</span> (<span id="os-name">...</span> <span id="os-arch">...</span>)</p>
+        <p>System Time: <span id="system-time">...</span></p>
+        <p>Uptime: <span id="uptime">...</span></p>
+      </div>
       <h1>Go Glances</h1>
       <div class="stats-grid">
         <div class="stats-card">

--- a/web/script.js
+++ b/web/script.js
@@ -3,6 +3,28 @@ let sortColumn = 'cpu';
 let sortAsc = false;
 let pinnedPids = [];
 
+function formatUptime(seconds) {
+    const d = Math.floor(seconds / (3600*24));
+    const h = Math.floor(seconds % (3600*24) / 3600);
+    const m = Math.floor(seconds % 3600 / 60);
+    const s = Math.floor(seconds % 60);
+
+    let result = '';
+    if (d > 0) {
+        result += `${d}d `;
+    }
+    if (h > 0) {
+        result += `${h}h `;
+    }
+    if (m > 0) {
+        result += `${m}m `;
+    }
+    if (s > 0) {
+        result += `${s}s`;
+    }
+    return result;
+}
+
 function fetchStats() {
     fetch('/stats')
         .then(response => response.json())
@@ -21,7 +43,13 @@ function fetchStats() {
             document.getElementById('mem-total').textContent = memTotalGB;
             document.getElementById('mem-percent').textContent = data.mem_used_percent.toFixed(2);
 
-            
+            // Update OS, Uptime and System Time
+            document.getElementById('os-distro').textContent = data.os.distro;
+            document.getElementById('os-name').textContent = data.os.name;
+            document.getElementById('os-arch').textContent = data.os.architecture;
+            document.getElementById('system-time').textContent = new Date().toLocaleTimeString();
+            document.getElementById('uptime').textContent = formatUptime(data.uptime);
+
             processesData = data.processes || [];
             renderTables();
 

--- a/web/style.css
+++ b/web/style.css
@@ -18,6 +18,12 @@ h1 {
     margin-bottom: 2em;
 }
 
+#system-info-container {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 20px;
+}
+
 .stats-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
- Adds OS, system time, and uptime to the web UI, including architecture and distribution.
- OS is top-left, time is top-middle, and uptime is top-right.

Closes #8 