### PR TITLE
Add click-to-copy for OS, CPU model, and process names (issue #24)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -13,8 +13,8 @@
 <body>
     <div class="container">
         <div id="system-info-container">
-            <p><span data-i18n="os"></span><span id="os-distro">...</span> (<span id="os-name">...</span> <span
-                    id="os-arch">...</span>)</p>
+            <p><span data-i18n="os"></span><span id="os-info" class="copy-text"><span id="os-distro">...</span> (<span
+                        id="os-name">...</span> <span id="os-arch">...</span>)</span></p>
             <p><span data-i18n="system_time"></span><span id="system-time">...</span></p>
             <p><span data-i18n="uptime"></span><span id="uptime">...</span></p>
         </div>
@@ -42,7 +42,7 @@
                 </div>
                 <div id="cpu-info-container">
                     <p><span data-i18n="cpu_model" class="label"></span><span id="cpu-model-name"
-                            class="value">...</span></p>
+                            class="value copy-text">...</span></p>
                     <p><span data-i18n="cpu_cores" class="label"></span><span id="cpu-cores" class="value">...</span>
                     </p>
                     <p><span data-i18n="cpu_max_frequency" class="label"></span><span id="cpu-frequency"

--- a/web/script.js
+++ b/web/script.js
@@ -85,6 +85,18 @@ function updateUsageBar(barId, percentage) {
     }
 }
 
+async function copyText(el) {
+    const text = el.textContent.trim();
+
+    try {
+        await navigator.clipboard.writeText(text);
+        el.setAttribute("data-tooltip", "Copied!");
+    } catch (err) {
+        console.error("Failed:", err);
+        el.setAttribute("data-tooltip", "Failed");
+    }
+}
+
 function fetchStats() {
     fetch('/stats')
         .then(response => {
@@ -230,7 +242,11 @@ function renderTables() {
             <td>${proc.threads}</td>
             <td>${proc.nice}</td>
             <td>${proc.status}</td>
-            <td>${proc.name}</td>
+            <td class="process-name-cell">
+                <span class="copy-text process-name-text" data-tooltip="Click to copy">
+                    ${proc.name}
+                </span>
+            </td>
         `;
         row.dataset.pid = proc.pid;
 
@@ -345,6 +361,11 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.getElementById('process-list-body').addEventListener('click', e => {
+        const nameText = e.target.closest('.process-name-text');
+        if (nameText) {
+            copyText(nameText);
+            return;
+        }
         const row = e.target.closest('tr');
         if (row) {
             togglePin(parseInt(row.dataset.pid, 10));
@@ -352,10 +373,41 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.getElementById('pinned-process-list-body').addEventListener('click', e => {
+        const nameText = e.target.closest('.process-name-text');
+        if (nameText) {
+            copyText(nameText);
+            return;
+        }
+
         const row = e.target.closest('tr');
         if (row) {
             togglePin(parseInt(row.dataset.pid, 10));
         }
+    });
+
+    document.getElementById('process-list-body').addEventListener('mouseover', e => {
+        const nameText = e.target.closest('.process-name-text');
+        if (nameText) {
+            nameText.setAttribute('data-tooltip', 'Click to copy');
+        }
+    });
+
+    document.getElementById('pinned-process-list-body').addEventListener('mouseover', e => {
+        const nameText = e.target.closest('.process-name-text');
+        if (nameText) {
+            nameText.setAttribute('data-tooltip', 'Click to copy');
+        }
+    });
+
+    const items = document.querySelectorAll(".copy-text");
+    items.forEach((el) => {
+        el.addEventListener("mouseenter", () => {
+            el.setAttribute("data-tooltip", "Click to copy");
+        });
+
+        el.addEventListener("click", () => {
+            copyText(el);
+        });
     });
 });
 

--- a/web/style.css
+++ b/web/style.css
@@ -367,3 +367,35 @@ h1 {
 .core-usage-bar.medium-usage {
     background: linear-gradient(90deg, #dcdcaa, #d7ba7d);
 }
+
+.copy-text {
+    position: relative;
+    cursor: pointer;
+}
+
+.copy-text::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    top: -120%;
+    left: 50%;
+    transform: translateX(-50%);
+
+    padding: 4px 8px;
+    border-radius: 4px;
+    background: #333;
+    color: #fff;
+    font-size: 12px;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+    z-index: 10;
+}
+
+.copy-text:hover::after {
+    opacity: 1;
+}
+
+.copy-text:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
This PR adds click-to-copy behavior to key system information:

- OS line (distro, name, arch)
- CPU model name
- Process names in both main and pinned process tables

Fixes #24
